### PR TITLE
Add pagination to transactions list and update template structure

### DIFF
--- a/cashflow/settings.py
+++ b/cashflow/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     "django_htmx",
     "django.contrib.humanize",
+    "template_partials",
     # project apps
     "tracker",
 ]
@@ -150,3 +151,5 @@ INTERNAL_IPS = [
 
 AUTH_USER_MODEL = 'tracker.User'
 LOGIN_REDIRECT_URL = 'index'
+
+PAGE_SIZE = 5

--- a/tracker/templates/tracker/partials/transactions-container.html
+++ b/tracker/templates/tracker/partials/transactions-container.html
@@ -1,5 +1,6 @@
-{% load widget_tweaks %}
+{% load partials %}
 {% load humanize %}
+{% load widget_tweaks %}
 
 <div class="flex flex-col-reverse md:grid md:grid-cols-4 gap-4" id="transaction-container" >
         <div class="col-span-3"> 
@@ -40,7 +41,8 @@
                 </a>
             </div>
                
-                {% if filter.qs %}
+                {% if transactions %}
+
                 <table class="table border-collapse border border-gray-600">
                     <thead class="text-sm text-white uppercase">
                     <tr>
@@ -52,35 +54,45 @@
                     </tr>
                     </thead>
                     <tbody>
-                        {% for transaction in filter.qs %}
-                    <tr>
-                        <th class="border border-gray-600">{{transaction.date}}</th>
-                        <td class="border border-gray-600">{{transaction.category}}</td>
-                        <td class="border border-gray-600">{{transaction.type}}</td>
-                        <td class="border border-gray-600">₹{{transaction.amount|floatformat:2}}</td>
-                        <td class="border border-gray-600 flex justify-between">
-                            <a hx-get="{% url 'update-transaction' transaction.pk %}"
-                                hx-push-url="true"
-                                hx-target="#transaction-block"
-                                class="cursor-pointer"
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-                                </svg>
-                            </a>
-                            <a hx-delete="{% url 'delete-transaction' transaction.pk %}"
-                                hx-push-url="true"
-                                hx-target="#transaction-block"
-                                hx-confirm="Are you sure you want to delete this transaction?"
-                                class="cursor-pointer"
-                            >
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                                </svg>
-                            </a>
-                        </td>
-                    </tr>
+                    {% partialdef transaction_list inline=True %}
+                    {% for transaction in transactions %}
+                        {% if forloop.last and transactions.has_next %}
+                            <tr hx-get="{% url 'get-transactions' %}?page={{transactions.next_page_number}}"
+                                hx-trigger="revealed"
+                                hx-swap="afterend"
+                                hx-include="#filterform"
+                                >
+                            {% else %}
+                            <tr >
+                            {% endif %}
+                                <th class="border border-gray-600">{{transaction.date}}</th>
+                                <td class="border border-gray-600">{{transaction.category}}</td>
+                                <td class="border border-gray-600">{{transaction.type}}</td>
+                                <td class="border border-gray-600">₹{{transaction.amount|floatformat:2}}</td>
+                                <td class="border border-gray-600 flex justify-between">
+                                    <a hx-get="{% url 'update-transaction' transaction.pk %}"
+                                        hx-push-url="true"
+                                        hx-target="#transaction-block"
+                                        class="cursor-pointer"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                                        </svg>
+                                    </a>
+                                    <a hx-delete="{% url 'delete-transaction' transaction.pk %}"
+                                        hx-push-url="true"
+                                        hx-target="#transaction-block"
+                                        hx-confirm="Are you sure you want to delete this transaction?"
+                                        class="cursor-pointer"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                        </svg>
+                                    </a>
+                                </td>
+                            </tr>
                     {% endfor %}
+                    {% endpartialdef %}
                     </tbody>
                 </table>
 
@@ -94,6 +106,7 @@
                 <form hx-get="{% url "transactions-list" %}"
                     hx-target="#transaction-container"
                     hx-swap="outerHTML"
+                    id="filterform"
                 >
                     <div class="mb-2 form-control"> 
                         {{ filter.form.transaction_type | add_label_class:"label text-white" }}

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('transactions/',views.transactions_list, name="transactions-list"),
     path('transactions/create',views.create_transaction, name="create-transaction"),
     path('transactions/<int:pk>/update/',views.update_transaction, name="update-transaction"),
-    path('transactions/<int:pk>/delete/',views.delete_transaction, name="delete-transaction")
+    path('transactions/<int:pk>/delete/',views.delete_transaction, name="delete-transaction"),
+    path('get-transactions/',views.get_transactions, name="get-transactions")
 ]

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django_htmx.http import retarget
+from django.core.paginator import Paginator
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
@@ -16,9 +18,14 @@ def transactions_list(request):
         request.GET,
         queryset=Transaction.objects.filter(user=request.user).select_related("category")
     )
+    
+    paginator = Paginator(transaction_filter.qs,settings.PAGE_SIZE)
+    transaction_page = paginator.page(1)
+
     total_income = transaction_filter.qs.get_total_income()
     total_expenses = transaction_filter.qs.get_total_expenses()
     context = {
+        'transactions':transaction_page,
         'filter':transaction_filter,
         'total_income':total_income,
         'total_expenses':total_expenses,
@@ -80,3 +87,17 @@ def delete_transaction(request,pk):
         "message": f"Transaction of {transaction.amount} on {transaction.date} was deleted successfully."
     }
     return render(request,'tracker/partials/transaction-success.html', context)
+
+@login_required
+def get_transactions(request):
+    page = request.GET.get('page', 1)
+    transaction_filter = TransactionFilter(
+        request.GET,
+        queryset=Transaction.objects.filter(user=request.user).select_related("category")
+    )
+    paginator = Paginator(transaction_filter.qs,settings.PAGE_SIZE)
+    context = {
+        'transactions': paginator.page(page)
+    }
+    
+    return render(request,'tracker/partials/transactions-container.html#transaction_list',context)


### PR DESCRIPTION
- Introduced a new `get_transactions` view to handle paginated transaction retrieval.
- Updated `transactions-container.html` to utilize partials for rendering transaction lists.
- Added `PAGE_SIZE` setting to control the number of transactions displayed per page.
- Modified URL patterns to include the new `get-transactions` endpoint.